### PR TITLE
feat(common.scss): improve code markup

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -28,3 +28,11 @@
 	border-radius: 2px;
 	transform: translateY(-3px);
 }
+
+// improve rendering of "inline code" markup
+p > code, li > code, pre {
+	margin: 0px 2px 0px 2px;
+	padding: 0px 5px 0px 5px;
+	background: var(--primary-very-low);
+	border-radius: 5px;
+}


### PR DESCRIPTION
Hello, here is a quick change to improve rendering of inline code markup (`this`) for ACES Central.

- more readable background
    - not sure the variable used is the most appropriate but its name make sense for the intended context
- Added padding on left-and right only :
    - no padding on top as without increasing the top margin, 2 block on following lines would superpose and "merge".
- Added small left-right margin :
    - no top/bottom to keep the visual difference minimal, but it would be nice to have, so we can add more top/bottom padding
- added round corners
    - less agressive/sharp look (what's being done by a bit of everybody, github, discord, ...)

I do think the padding/margin changes are quite subjective so let me know if they are not desirable. 

side-effect might be some line breaking earlier than before as this markup is now wider (due to margin and padding)

please note that I did not test the changes directly with discourse so I cannot guarantee that they will work once "deployed"

# result

change where previewed using a browser extension to customize CSS per page

![2023_11_14_191712_794x412](https://github.com/ampas/discourse-acescentral-theme/assets/64362465/1ba407d1-a62d-4d08-af8c-4548fab528bb)
![2023_11_14_191729_794x412](https://github.com/ampas/discourse-acescentral-theme/assets/64362465/f3eb497f-8e62-4328-8f8d-f5a02da6f67a)
![2023_11_14_191752_794x412](https://github.com/ampas/discourse-acescentral-theme/assets/64362465/d259fd08-aaba-45c5-8bd7-3b943baca343)

here is a "before"
![image](https://github.com/ampas/discourse-acescentral-theme/assets/64362465/ab07e00d-db42-4003-a3e5-223c4f49f984)


