### PR TITLE
fix(common.scss): inline code formatting applied to code blocks

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -30,7 +30,7 @@
 }
 
 // improve rendering of "inline code" markup
-p > code, li > code, pre {
+p > code, li > code, pre:not(.codeblock-buttons) {
 	margin: 0px 2px 0px 2px;
 	padding: 0px 5px 0px 5px;
 	background: var(--primary-very-low);


### PR DESCRIPTION
make the css selector more explicit so the change made in #7 doesn't affect regular code blocks (`pre` blocks with a `codeblock-buttons` class).

# compatibility

Use of the `:not` selector :
https://developer.mozilla.org/en-US/docs/Web/CSS/:not#browser_compatibility
Which is compatible with all modern web-browser, as [part of CSS3 spec](https://drafts.csswg.org/selectors-3/#negation)

# comparison

before:
![image](https://github.com/ampas/discourse-acescentral-theme/assets/64362465/6daee162-32f6-4d75-9bd0-2f4b9854d51f)

after:
![2023_11_19_204925_828x592](https://github.com/ampas/discourse-acescentral-theme/assets/64362465/7c465c15-7f85-4218-8ee7-784cbaeb62cb)
